### PR TITLE
Feature element workflow

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,4 +1,24 @@
+---
+Name: workflow_actions_styles
+---
 # admin files
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_css:
     - 'symbiote-library/silverstripe-workflow-actions:client/styles/admin.css'
+
+---
+Name: workflow_actions_extensions
+---
+Page:
+  extensions:
+    - Symbiote\AdvancedWorkflow\Extension\WorkflowFieldCapture
+    - Symbiote\AdvancedWorkflow\Extension\ContentApproversExtension
+Symbiote\AdvancedWorkflow\DataObjects\WorkflowActionInstance:
+  extensions:
+    - Symbiote\AdvancedWorkflow\Extension\WorkflowActionInstanceExtension
+SilverStripe\CMS\Controllers\CMSPageEditController:
+  extensions:
+    - Symbiote\AdvancedWorkflow\Extension\RightsideWorkflow
+SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
+  extensions:
+    - Symbiote\AdvancedWorkflow\Extension\RightsideWorkflow

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,4 @@
+# admin files
+SilverStripe\Admin\LeftAndMain:
+  extra_requirements_css:
+    - 'symbiote-library/silverstripe-workflow-actions:client/styles/admin.css'

--- a/client/styles/admin.css
+++ b/client/styles/admin.css
@@ -7,7 +7,23 @@
     vertical-align: middle;
 }
 
-/* tooltip styling */
+/* SelectElement readonly styling */
+.wfa-right-elements-list.wfa-readonly ul {
+    color: #43536d;
+    padding-left: 3px;
+    background-color: #f1f3f6;
+    border-radius: 3px;
+    border: 1px solid #e7ebf0;
+}
+.wfa-right-elements-list.wfa-readonly ul:after {
+    float: right;
+    font-size: .85rem;
+    font-style: italic;
+    color: #566b8d;
+    content: 'readonly';
+}
+
+/* SelectElement tooltip styling */
 .wfa-right-elements-list label {
     position: relative;
     vertical-align: middle;

--- a/client/styles/admin.css
+++ b/client/styles/admin.css
@@ -1,0 +1,4 @@
+.workflow-right-elements-list {
+    padding-left: 0;
+    list-style-type: none;
+}

--- a/client/styles/admin.css
+++ b/client/styles/admin.css
@@ -1,4 +1,4 @@
-/* SelectElement styling */
+/* SelectElement */
 .wfa-right-elements-list {
     padding-left: 0;
     list-style-type: none;
@@ -54,12 +54,18 @@
     visibility: visible;
 }
 
+/* hide sidebar header */
+#WorkflowHeader {
+    display: none;
+}
+
 /* fix for rightsidebar overlapping root form */
 .rightsidebar-inner {
     margin-right: 260px;
 }
 .rightsidebar {
     right: 15px !important;
+    padding-top: 40px;
 }
 @media (max-width: 991px) {
     .rightsidebar {

--- a/client/styles/admin.css
+++ b/client/styles/admin.css
@@ -1,8 +1,21 @@
+/* SelectElement styling */
 .workflow-right-elements-list {
     padding-left: 0;
     list-style-type: none;
 }
-
 .workflow-right-elements-list input.checkbox {
     vertical-align: text-bottom;
+}
+
+/* fix for rightsidebar overlapping root form */
+.rightsidebar-inner {
+    margin-right: 260px;
+}
+.rightsidebar {
+    right: 15px !important;
+}
+@media (max-width: 991px) {
+    .rightsidebar {
+        right: 0px !important;
+    }
 }

--- a/client/styles/admin.css
+++ b/client/styles/admin.css
@@ -2,3 +2,7 @@
     padding-left: 0;
     list-style-type: none;
 }
+
+.workflow-right-elements-list input.checkbox {
+    vertical-align: text-bottom;
+}

--- a/client/styles/admin.css
+++ b/client/styles/admin.css
@@ -1,10 +1,41 @@
 /* SelectElement styling */
-.workflow-right-elements-list {
+.wfa-right-elements-list {
     padding-left: 0;
     list-style-type: none;
 }
-.workflow-right-elements-list input.checkbox {
-    vertical-align: text-bottom;
+.wfa-right-elements-list input.checkbox {
+    vertical-align: middle;
+}
+
+/* tooltip styling */
+.wfa-right-elements-list label {
+    position: relative;
+    vertical-align: middle;
+    max-width: 85%;
+    margin: .2rem 0;
+}
+.wfa-right-elements-list .wfa-trunc {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.wfa-right-elements-list .wfa-tip {
+    visibility: hidden;
+    position: absolute;
+    z-index: 1;
+    top: 2rem;
+    left: 0px;
+    width: 180px;
+    padding: 5px;
+    color: #566b8d;
+    font-size: .923rem;
+    background-color: seashell;
+    border: 1px solid #566b8d;
+    border-radius: 3px;
+    pointer-events: none;
+}
+.wfa-right-elements-list li:hover .wfa-tip {
+    visibility: visible;
 }
 
 /* fix for rightsidebar overlapping root form */

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.0"
+        "silverstripe/framework": "^4.0",
+        "symbiote/silverstripe-advancedworkflow": "^5.0",
+        "symbiote/silverstripe-multivaluefield": "^5.0",
+        "micschk/silverstripe-rightsidebar": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
             "dev-master": "1.0.x-dev"
         },
         "expose": [
-          "client/images"
+          "client/"
         ]
     },
     "prefer-stable": true,

--- a/src/Actions/PublishWithSelectedElementsActions.php
+++ b/src/Actions/PublishWithSelectedElementsActions.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Symbiote\AdvancedWorkflow\Actions;
+
+use SilverStripe\ORM\ArrayList;
+use Symbiote\AdvancedWorkflow\Actions\PublishItemWorkflowAction;
+use Symbiote\AdvancedWorkflow\Actions\SelectElementsInstance;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
+use Symbiote\AdvancedWorkflow\Extensions\WorkflowEmbargoExpiryExtension;
+
+class PublishWithSelectedElementsActions extends PublishItemWorkflowAction
+{
+    /**
+     * Override of base execute() so that we can publish only selected
+     * elements.
+     *
+     * @param WorkflowInstance $workflow
+     * @return bool
+     */
+    public function execute(WorkflowInstance $workflow)
+    {
+        if (!$target = $workflow->getTarget()) {
+            return true;
+        }
+
+        // TODO: Add back queued jobs logic with new job, etc.
+
+        if ($target->hasExtension(WorkflowEmbargoExpiryExtension::class)) {
+            $target->AllowEmbargoedEditing = $this->AllowEmbargoedEditing;
+            $target->UnPublishOnDate = $target->DesiredUnPublishDate;
+            $target->DesiredUnPublishDate = '';
+
+            if ($target->DesiredPublishDate) {
+                $target->PublishOnDate = $target->DesiredPublishDate;
+                $target->DesiredPublishDate = '';
+                $target->write();
+            } else {
+                $target->write();
+                $this->executePublish($target, $workflow);
+            }
+        } else {
+            $this->executePublish($target, $workflow);
+        }
+
+        return true;
+    }
+
+    /**
+     * Publish the target and the selected elements.
+     *
+     * @param Page $target
+     * @param WorkflowInstance $workflow
+     * @return void
+     */
+    public function executePublish($target, $workflow)
+    {
+        if ($target->hasMethod('publishSingle')) {
+            $target->publishSingle();
+        }
+
+        try {
+            $elements = $target->ElementalArea()->Elements();
+            $selected = SelectElementsInstance::findInWorkflow($workflow)->getSelectedElementsIDs();
+        } catch (\Exception $e) {
+            $elements = new ArrayList();
+            $selected = [];
+        }
+
+        if ($elements->count() && count($selected)) {
+            $filtered = $elements->filter([ 'ID' => $selected ]);
+            foreach ($filtered as $ele) {
+                if ($ele->hasMethod('publishRecursive')) {
+                    $ele->publishRecursive();
+                } else if ($ele->hasMethod('publishSingle')) {
+                    $ele->publishSingle();
+                }
+            }
+        }
+    }
+}

--- a/src/Actions/PublishWithSelectedElementsActions.php
+++ b/src/Actions/PublishWithSelectedElementsActions.php
@@ -23,7 +23,7 @@ class PublishWithSelectedElementsActions extends PublishItemWorkflowAction
             return true;
         }
 
-        // TODO: Add back queued jobs logic with new job, etc.
+        // TODO: Add queued jobs logic with 'selected elements' job, etc.
 
         if ($target->hasExtension(WorkflowEmbargoExpiryExtension::class)) {
             $target->AllowEmbargoedEditing = $this->AllowEmbargoedEditing;

--- a/src/Actions/SelectElementsAction.php
+++ b/src/Actions/SelectElementsAction.php
@@ -22,7 +22,7 @@ class SelectElementsAction extends WorkflowAction
 
     public function execute(WorkflowInstance $workflow)
     {
-        // see SelectElementsInstance::onSaveWorkflowPage()
+        // see SelectElementsInstance::onSaveWorkflowState()
         return true;
     }
 }

--- a/src/Actions/SelectElementsAction.php
+++ b/src/Actions/SelectElementsAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Symbiote\AdvancedWorkflow\Actions;
+
+use SilverStripe\Security\Group;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\DropdownField;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowAction;
+use Symbiote\AdvancedWorkflow\Extension\ContentApproversExtension;
+
+class SelectElementsAction extends WorkflowAction
+{
+    private static $icon = 'symbiote/silverstripe-advancedworkflow:images/assign.png';
+
+    private static $table_name = 'SelectElementsAction';
+
+    private static $instance_class = SelectElementsInstance::class;
+
+    private static $db = [];
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+
+        return $fields;
+    }
+
+    public function execute(WorkflowInstance $workflow)
+    {
+        $target = $workflow->getTarget();
+
+        return true;
+    }
+}

--- a/src/Actions/SelectElementsAction.php
+++ b/src/Actions/SelectElementsAction.php
@@ -2,12 +2,8 @@
 
 namespace Symbiote\AdvancedWorkflow\Actions;
 
-use SilverStripe\Security\Group;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
-use SilverStripe\Forms\CheckboxField;
-use SilverStripe\Forms\DropdownField;
 use Symbiote\AdvancedWorkflow\DataObjects\WorkflowAction;
-use Symbiote\AdvancedWorkflow\Extension\ContentApproversExtension;
 
 class SelectElementsAction extends WorkflowAction
 {
@@ -21,15 +17,12 @@ class SelectElementsAction extends WorkflowAction
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
-
-        return $fields;
+        return parent::getCMSFields();
     }
 
     public function execute(WorkflowInstance $workflow)
     {
-        $target = $workflow->getTarget();
-
+        // see SelectElementsInstance::onSaveWorkflowPage()
         return true;
     }
 }

--- a/src/Actions/SelectElementsInstance.php
+++ b/src/Actions/SelectElementsInstance.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symbiote\AdvancedWorkflow\Actions;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldGroup;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Control\Controller;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowInstance;
+use Symbiote\AdvancedWorkflow\DataObjects\WorkflowActionInstance;
+use Symbiote\MultiValueField\Fields\MultiValueCheckboxField;
+use Symbiote\MultiValueField\ORM\FieldType\MultiValueField;
+
+class SelectElementsInstance extends WorkflowActionInstance
+{
+    private static $db = [
+        'SelectedElements' => MultiValueField::class
+    ];
+
+    private static $table_name = 'SelectElementsInstance';
+
+    public function updateWorkflowFields($fields)
+    {
+        parent::updateWorkflowFields($fields);
+
+        $elements = Controller::curr()->currentPage()->ElementalArea()->Elements();
+
+        $options = [];
+        foreach ($elements as $e) {
+            $options[$e->ID] = $this->listOptionHTML($e->ID, $e->Title, $e->getType());
+        }
+
+        $fields->push(
+            MultiValueCheckboxField::create('SelectedElements', 'Selected elements', $options)
+                ->setDescription(
+                    '<em>Selected elements will have their changes published as part of this workflow.'.
+                    '<br><br>Save or refresh page to update list.</em>'
+                )
+                ->addExtraClass('wfa-right-elements-list')
+        );
+    }
+
+    public function onSaveWorkflowPage($page, $postVars)
+    {
+        parent::onSaveWorkflowPage($page, $postVars);
+
+        $selected = isset($postVars['SelectedElements']) ? array_keys($postVars['SelectedElements']) : [];
+        $this->SelectedElements->setValue($selected);
+    }
+
+    protected function listOptionHTML($id, $title, $type)
+    {
+        // label
+        $label = $title ?: '<em>untitled</em>';
+        $html = "<div class=\"wfa-trunc\">{$label}</div>";
+        // tooltip
+        $tip = $type ?: 'no type';
+        $html .= "<div class=\"wfa-tip\">#{$id} <strong>{$label}</strong><br><em>&lt;{$tip}&gt;</em></div>";
+
+        return $html;
+    }
+}

--- a/src/Actions/SelectElementsInstance.php
+++ b/src/Actions/SelectElementsInstance.php
@@ -31,10 +31,10 @@ class SelectElementsInstance extends WorkflowActionInstance
     {
         parent::updateWorkflowFields($fields);
 
-        $fields->push($this->getSelectionList());
+        $fields->push($this->getSelectedElementsField());
     }
 
-    public function getSelectionList($readonly = false)
+    public function getSelectedElementsField($readonly = false)
     {
         try {
             $elements = Controller::curr()->currentPage()->ElementalArea()->Elements();
@@ -62,6 +62,12 @@ class SelectElementsInstance extends WorkflowActionInstance
         }
 
         return $checklist;
+    }
+
+    public function getSelectedElementsIDs()
+    {
+        $vals = $this->SelectedElements->getValue();
+        return array_values($vals);
     }
 
     public static function findInWorkflow($wfInstance)

--- a/src/Actions/SelectElementsInstance.php
+++ b/src/Actions/SelectElementsInstance.php
@@ -18,19 +18,17 @@ class SelectElementsInstance extends WorkflowActionInstance
     private static $table_name = 'SelectElementsInstance';
 
     /**
-     * Hook into page save event
+     * Hook into object save event
      *
      * @see WorkflowFieldCapture
      *
-     * @param Page $page
+     * @param DataObject $object
      * @param array $postVars
      * @return void
      */
-    public function onSaveWorkflowPage($page, $postVars)
+    public function onSaveWorkflowState($object, $postVars)
     {
-        parent::onSaveWorkflowPage($page, $postVars);
-
-        // store selected elements
+        // store selected elements (inc none to allow for deselecting)
         $selected = isset($postVars['SelectedElements']) ? $postVars['SelectedElements'] : [];
         $this->SelectedElements->setValue($selected);
     }

--- a/src/Extension/RightsideWorkflow.php
+++ b/src/Extension/RightsideWorkflow.php
@@ -38,8 +38,7 @@ class RightsideWorkflow extends Extension
         $form->Fields()->removeByName('WorkflowActions');
 
         $form->Fields()->insertBefore($sb, 'Root');
-        $form->Fields()->fieldByName('Root')->setTemplate('RightSidebar');
-
+        $form->Fields()->fieldByName('Root')->setTemplate('Restruct\RightSidebar\Forms\RightSidebarInner');
 
         // use any workflow settings for extra required fields
         $required = $this->owner->config()->required_fields;

--- a/src/Extension/RightsideWorkflow.php
+++ b/src/Extension/RightsideWorkflow.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\Form;
 use Restruct\RightSidebar\RightSidebar;
 use SilverStripe\Forms\RequiredFields;
 use Symbiote\AdvancedWorkflow\Actions\RequireFieldsActionInstance;
+use Symbiote\AdvancedWorkflow\Actions\SelectElementsInstance;
 use Symbiote\AdvancedWorkflow\Services\WorkflowService;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\i18n\i18n;
@@ -64,6 +65,13 @@ class RightsideWorkflow extends Extension
                     'Comment',
                     LiteralField::create('RequireWfFields', $label)
                 );
+            }
+        }
+
+        // show readonly selected elements list where appropriate
+        if (!($action instanceof SelectElementsInstance)) {
+            if ($sei = SelectElementsInstance::findInWorkflow($active)) {
+                $sb->push($sei->getSelectionList(true));
             }
         }
 

--- a/src/Extension/RightsideWorkflow.php
+++ b/src/Extension/RightsideWorkflow.php
@@ -71,7 +71,7 @@ class RightsideWorkflow extends Extension
         // show readonly selected elements list where appropriate
         if (!($action instanceof SelectElementsInstance)) {
             if ($sei = SelectElementsInstance::findInWorkflow($active)) {
-                $sb->push($sei->getSelectionList(true));
+                $sb->push($sei->getSelectedElementsField(true));
             }
         }
 

--- a/src/Extension/WorkflowActionInstanceExtension.php
+++ b/src/Extension/WorkflowActionInstanceExtension.php
@@ -6,34 +6,19 @@ use SilverStripe\ORM\DataExtension;
 
 class WorkflowActionInstanceExtension extends DataExtension
 {
-    private $brokenOnSaveWorkflowPage = false;
-
     /**
-     * Override this in descendants of `WorkflowActionInstance`
+     * Hook into object save event
      *
-     * @param Page $page The page object being saved
-     * @param array $postVars The submitted fields/values
+     * @see WorkflowFieldCapture
+     *
+     * @param DataObject $object
+     * @param array $postVars
      * @return void
      */
-    public function onSaveWorkflowPage($page, $postVars)
+    public function onSaveWorkflowState($object, $postVars)
     {
-        $this->brokenOnSaveWorkflowPage = false;
-
         if (isset($postVars['Comment'])) {
             $this->getOwner()->Comment = $postVars['Comment'];
-        }
-    }
-
-    public function preSaveWorkflowPage()
-    {
-        $this->brokenOnSaveWorkflowPage = true;
-    }
-
-    public function postSaveWorkflowPage()
-    {
-        if ($this->brokenOnSaveWorkflowPage) {
-            user_error(static::class . " has a broken onSaveWorkflowPage() function."
-                . " Make sure that you call parent::onSaveWorkflowPage().", E_USER_ERROR);
         }
     }
 }

--- a/src/Extension/WorkflowActionInstanceExtension.php
+++ b/src/Extension/WorkflowActionInstanceExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Symbiote\AdvancedWorkflow\Extension;
+
+use SilverStripe\ORM\DataExtension;
+
+class WorkflowActionInstanceExtension extends DataExtension
+{
+    private $brokenOnSaveWorkflowPage = false;
+
+    /**
+     * Override this in descendants of `WorkflowActionInstance`
+     *
+     * @param Page $page The page object being saved
+     * @param array $postVars The submitted fields/values
+     * @return void
+     */
+    public function onSaveWorkflowPage($page, $postVars)
+    {
+        $this->brokenOnSaveWorkflowPage = false;
+
+        if (isset($postVars['Comment'])) {
+            $this->getOwner()->Comment = $postVars['Comment'];
+        }
+    }
+
+    public function preSaveWorkflowPage()
+    {
+        $this->brokenOnSaveWorkflowPage = true;
+    }
+
+    public function postSaveWorkflowPage()
+    {
+        if ($this->brokenOnSaveWorkflowPage) {
+            user_error(static::class . " has a broken onSaveWorkflowPage() function."
+                . " Make sure that you call parent::onSaveWorkflowPage().", E_USER_ERROR);
+        }
+    }
+}

--- a/src/Extension/WorkflowFieldCapture.php
+++ b/src/Extension/WorkflowFieldCapture.php
@@ -13,18 +13,17 @@ class WorkflowFieldCapture extends DataExtension
 {
     public function onBeforeWrite()
     {
-        // we know that owner is a Page and that all Pages have this extension
-        if ($wfi = $this->owner->getWorkflowInstance()) {
+        // get workflow
+        if ($this->owner->hasMethod('getWorkflowInstance') && $wfi = $this->owner->getWorkflowInstance()) {
+            // get curr action
             if ($action = $wfi->CurrentAction()) {
-                // incase a page is saved via means other than form submission
+                // incase this isn't an edit form submission
                 try {
                     $postVars = Controller::curr()->getRequest()->postVars();
                 } catch (\Exception $e) {
                     $postVars = [];
                 }
-                $action->preSaveWorkflowPage();
-                $action->onSaveWorkflowPage($this->owner, $postVars);
-                $action->postSaveWorkflowPage();
+                $action->invokeWithExtensions('onSaveWorkflowState', $this->owner, $postVars);
                 $action->write();
             }
         }

--- a/src/Extension/WorkflowFieldCapture.php
+++ b/src/Extension/WorkflowFieldCapture.php
@@ -2,8 +2,8 @@
 
 namespace Symbiote\AdvancedWorkflow\Extension;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\ORM\DataExtension;
-
 /**
  * Captures workflow fields entered when a user hits
  * "save" instead of a workflow trigger
@@ -12,6 +12,7 @@ class WorkflowFieldCapture extends DataExtension
 {
     public function onBeforeWrite()
     {
+        // TODO: make this check for instance
         if ($this->owner->Comment) {
             // see if we've got an active workflow that might be interested in the
             // comment text
@@ -19,7 +20,10 @@ class WorkflowFieldCapture extends DataExtension
             if ($active) {
                 $action = $active->CurrentAction();
                 if ($action) {
-                    $action->update($this->owner->toMap());
+                    $postVars = Controller::curr()->getRequest()->postVars();
+                    $action->preSaveWorkflowPage();
+                    $action->onSaveWorkflowPage($this->owner, $postVars);
+                    $action->postSaveWorkflowPage();
                     $action->write();
                 }
             }

--- a/src/Extension/WorkflowedElement.php
+++ b/src/Extension/WorkflowedElement.php
@@ -22,7 +22,7 @@ class WorkflowedElement extends DataExtension
                     'wflMessage',
                     '<div class="message warning">This page is currently in workflow</div>'
                 );
-                $fields->insertBefore('TitleAndDisplayed', $msg);
+                $fields->insertBefore('Title', $msg);
             }
         }
     }


### PR DESCRIPTION
Add 2 new actions:
- `SelectElementsAction` for selecting elements via the right sidebar.
- `PublishWithSelectedElements` for publishing **only** the selected elements on the page (rather than all).

Additionally addresses:
- `update()` was being called on actions when the page was saved (no actions were using). The result was that `DataObject::update()` was called and it tried to write the Page data into the action, resulting in a bunch of junk entries in the DB table, etc.
- Adds composer requirements.
- Fixes some styling issues with the right sidebar. In particular that it was overlapping the edit form and hiding element controls, etc.
- Brings some config out of the project as defaults in the module.

Notes:

- I haven't looked into 'per elements change diffing' yet. That whole thing looks like it could use some improvement.